### PR TITLE
Support template variables in move and copy destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ is_hidden = true      # Match hidden files (starting with .)
 ```toml
 [rule.action]
 type = "move"
-destination = "~/Documents/Archive"
+destination = "~/Documents/Archive/{date:%Y%m%d}"
 create_destination = true  # Create folder if missing
 overwrite = false          # Don't overwrite existing files
 ```
@@ -379,7 +379,7 @@ overwrite = false          # Don't overwrite existing files
 ```toml
 [rule.action]
 type = "copy"
-destination = "~/Backup"
+destination = "~/Backup/{ext}/{name}"
 create_destination = true
 overwrite = false
 ```
@@ -392,7 +392,9 @@ type = "rename"
 pattern = "{date}_{name}.{ext}"
 ```
 
-**Available variables:**
+Move and copy destinations support the same template variables as rename patterns. Templates expand the destination folder; the original filename is preserved.
+
+**Available template variables:**
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -532,7 +534,7 @@ name_regex = "^invoice.*\\.pdf$"
 
 [rule.action]
 type = "rename"
-pattern = "{date:YYYY-MM-DD}_{filename}"
+pattern = "{date:%Y-%m-%d}_{filename}"
 ```
 </details>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,14 +453,14 @@ Move file to a destination folder. If the source and destination are on differen
 ```toml
 [rule.action]
 type = "move"
-destination = "~/Documents/Archive"
+destination = "~/Documents/Archive/{date:%Y%m%d}"
 create_destination = true  # Create folder if missing (default: true)
 overwrite = false          # Overwrite existing files (default: false)
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `destination` | string | — | Target directory (required) |
+| `destination` | string | — | Target directory; supports template variables (required) |
 | `create_destination` | bool | `true` | Create directory if it doesn't exist |
 | `overwrite` | bool | `false` | Overwrite if file exists at destination |
 
@@ -471,12 +471,14 @@ Copy file to a destination (original remains).
 ```toml
 [rule.action]
 type = "copy"
-destination = "~/Backup"
+destination = "~/Backup/{ext}/{name}"
 create_destination = true
 overwrite = false
 ```
 
 Same options as Move.
+
+Move and copy templates expand the destination directory only. Hazelnut preserves the original filename inside the expanded directory.
 
 ### Rename
 
@@ -488,7 +490,9 @@ type = "rename"
 pattern = "{date}_{name}.{ext}"
 ```
 
-#### Pattern Variables
+### Pattern Variables
+
+These variables are available in move and copy destination directories and in rename patterns.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -721,7 +725,7 @@ name = "Date-prefix invoices"
 name_regex = "^invoice.*\\.pdf$"
 [rule.action]
 type = "rename"
-pattern = "{date:YYYY-MM-DD}_{filename}"
+pattern = "{date:%Y-%m-%d}_{filename}"
 
 [[rule]]
 name = "Rename photos with datetime"

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -207,9 +207,7 @@ fn handle_dashboard_key(state: &mut AppState, key: KeyEvent) {
         KeyCode::Char('r') => state.view = View::Rules,
         KeyCode::Char('w') => state.view = View::Watches,
         KeyCode::Char('l') => state.view = View::Log,
-        KeyCode::Char('u') | KeyCode::Char('U')
-            if state.update_available.is_some() =>
-        {
+        KeyCode::Char('u') | KeyCode::Char('U') if state.update_available.is_some() => {
             state.mode = Mode::UpdateConfirm;
         }
         _ => {}

--- a/src/app/events.rs
+++ b/src/app/events.rs
@@ -207,10 +207,10 @@ fn handle_dashboard_key(state: &mut AppState, key: KeyEvent) {
         KeyCode::Char('r') => state.view = View::Rules,
         KeyCode::Char('w') => state.view = View::Watches,
         KeyCode::Char('l') => state.view = View::Log,
-        KeyCode::Char('u') | KeyCode::Char('U') => {
-            if state.update_available.is_some() {
-                state.mode = Mode::UpdateConfirm;
-            }
+        KeyCode::Char('u') | KeyCode::Char('U')
+            if state.update_available.is_some() =>
+        {
+            state.mode = Mode::UpdateConfirm;
         }
         _ => {}
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -622,7 +622,7 @@ impl WatchEditorState {
     ) -> Self {
         let path = watch.path.display().to_string();
         let cursor_path = path.len();
-        let rules_cursor = 0.min(available_rules.len().saturating_sub(1));
+        let rules_cursor = 0;
         Self {
             field: WatchEditorField::Path,
             editing_index: Some(index),

--- a/src/rules/action.rs
+++ b/src/rules/action.rs
@@ -20,6 +20,7 @@ static DATE_FORMAT_RE: LazyLock<Regex> =
 pub enum Action {
     /// Move file to a destination folder
     Move {
+        /// Destination folder (supports {name}, {ext}, {date}, etc.)
         destination: PathBuf,
         /// Create destination if it doesn't exist
         #[serde(default = "default_true")]
@@ -31,6 +32,7 @@ pub enum Action {
 
     /// Copy file to a destination folder
     Copy {
+        /// Destination folder (supports {name}, {ext}, {date}, etc.)
         destination: PathBuf,
         #[serde(default = "default_true")]
         create_destination: bool,
@@ -84,7 +86,7 @@ impl Action {
                 create_destination,
                 overwrite,
             } => {
-                let dest = expand_path(destination);
+                let dest = expand_destination(destination, path)?;
 
                 if *create_destination {
                     std::fs::create_dir_all(&dest).with_context(|| {
@@ -136,7 +138,7 @@ impl Action {
                 create_destination,
                 overwrite,
             } => {
-                let dest = expand_path(destination);
+                let dest = expand_destination(destination, path)?;
 
                 if *create_destination {
                     std::fs::create_dir_all(&dest)?;
@@ -464,6 +466,12 @@ fn expand_path(path: &Path) -> PathBuf {
     crate::expand_path(path)
 }
 
+/// Expand template variables, then home and environment variables, in a destination folder.
+fn expand_destination(destination: &Path, path: &Path) -> Result<PathBuf> {
+    let expanded = expand_pattern(&destination.to_string_lossy(), path)?;
+    Ok(expand_path(Path::new(&expanded)))
+}
+
 /// Internal pattern expansion with optional shell escaping of path-derived values.
 fn expand_pattern_inner(pattern: &str, path: &Path, shell_escape: bool) -> Result<String> {
     let mut result = pattern.to_string();
@@ -530,6 +538,8 @@ fn expand_pattern_shell_escaped(pattern: &str, path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Local;
+    use std::fs;
 
     #[test]
     fn test_expand_pattern() {
@@ -538,7 +548,16 @@ mod tests {
         assert_eq!(expand_pattern("{name}", path).unwrap(), "test");
         assert_eq!(expand_pattern("{ext}", path).unwrap(), "pdf");
         assert_eq!(expand_pattern("{filename}", path).unwrap(), "test.pdf");
+        assert_eq!(expand_pattern("{path}", path).unwrap(), "/tmp/test.pdf");
+        assert_eq!(expand_pattern("{dir}", path).unwrap(), "/tmp");
         assert_eq!(expand_pattern("{name}.{ext}", path).unwrap(), "test.pdf");
+        assert_eq!(expand_pattern("{unknown}", path).unwrap(), "{unknown}");
+
+        let date = expand_pattern("{date}", path).unwrap();
+        assert!(chrono::NaiveDate::parse_from_str(&date, "%Y-%m-%d").is_ok());
+
+        let datetime = expand_pattern("{datetime}", path).unwrap();
+        assert!(chrono::NaiveDateTime::parse_from_str(&datetime, "%Y-%m-%d_%H-%M-%S").is_ok());
     }
 
     #[test]
@@ -547,5 +566,93 @@ mod tests {
         let path = Path::new("~/Downloads");
         let expanded = expand_path(path);
         assert!(!expanded.to_string_lossy().contains('~'));
+    }
+
+    #[test]
+    fn move_expands_date_in_destination_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("report.txt");
+        fs::write(&source, "report contents").unwrap();
+
+        let destination = temp.path().join("archive").join("{date:%Y%m%d}");
+        let date_before = Local::now().format("%Y%m%d").to_string();
+        Action::Move {
+            destination: destination.clone(),
+            create_destination: true,
+            overwrite: false,
+        }
+        .execute(&source)
+        .unwrap();
+        let date_after = Local::now().format("%Y%m%d").to_string();
+
+        let moved_before = destination
+            .parent()
+            .unwrap()
+            .join(date_before)
+            .join("report.txt");
+        let moved_after = destination
+            .parent()
+            .unwrap()
+            .join(date_after)
+            .join("report.txt");
+        let moved = if moved_before.exists() {
+            moved_before
+        } else {
+            moved_after
+        };
+
+        assert!(!source.exists());
+        assert_eq!(fs::read_to_string(moved).unwrap(), "report contents");
+    }
+
+    #[test]
+    fn copy_expands_file_variables_in_destination_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("quarterly-report.pdf");
+        fs::write(&source, "copy contents").unwrap();
+
+        let destination = temp.path().join("backup").join("{ext}").join("{name}");
+        Action::Copy {
+            destination,
+            create_destination: true,
+            overwrite: false,
+        }
+        .execute(&source)
+        .unwrap();
+
+        let copied = temp
+            .path()
+            .join("backup/pdf/quarterly-report/quarterly-report.pdf");
+        assert_eq!(fs::read_to_string(&source).unwrap(), "copy contents");
+        assert_eq!(fs::read_to_string(copied).unwrap(), "copy contents");
+    }
+
+    #[test]
+    fn copy_rejects_existing_destination_when_overwrite_is_false() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("report.txt");
+        let destination = temp.path().join("backup").join("txt");
+        fs::create_dir_all(&destination).unwrap();
+        fs::write(&source, "new contents").unwrap();
+        fs::write(destination.join("report.txt"), "existing contents").unwrap();
+
+        let error = Action::Copy {
+            destination: temp.path().join("backup").join("{ext}"),
+            create_destination: true,
+            overwrite: false,
+        }
+        .execute(&source)
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Destination exists and overwrite is false")
+        );
+        assert_eq!(fs::read_to_string(&source).unwrap(), "new contents");
+        assert_eq!(
+            fs::read_to_string(destination.join("report.txt")).unwrap(),
+            "existing contents"
+        );
     }
 }

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -126,6 +126,8 @@ type = "trash"
 - `delete` - Permanently delete
 - `run` - Execute shell command
 
+Move and copy destinations support `{name}`, `{filename}`, `{ext}`, `{path}`, `{dir}`, `{date}`, `{datetime}`, and `{date:FORMAT}` template variables. Templates expand the destination folder, and Hazelnut preserves the original filename.
+
 ## Themes
 
 15 themes available via ratatui-themes:

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -530,7 +530,7 @@ age_days_less_than = 7  # Newer than 7 days`}</code></pre>
         <div class="code-block">
           <pre><code>{`[rule.action]
 type = "move"
-destination = "~/Documents/PDFs"
+destination = "~/Documents/Archive/{date:%Y%m%d}"
 create_destination = true  # Create folder if missing
 overwrite = false  # Don't overwrite existing files`}</code></pre>
         </div>
@@ -540,10 +540,12 @@ overwrite = false  # Don't overwrite existing files`}</code></pre>
         <div class="code-block">
           <pre><code>{`[rule.action]
 type = "copy"
-destination = "~/Backup"
+destination = "~/Backup/{ext}/{name}"
 create_destination = true
 overwrite = false`}</code></pre>
         </div>
+
+        <p>Move and copy templates expand the destination directory only. Hazelnut preserves the original filename inside the expanded directory.</p>
 
         <h3>Rename</h3>
         <div class="code-block">
@@ -552,7 +554,7 @@ type = "rename"
 pattern = "{date}_{name}.{ext}"`}</code></pre>
         </div>
 
-        <p>Available pattern variables:</p>
+        <p>Available destination and rename template variables:</p>
         <ul>
           <li><code>{`{name}`}</code> - Filename without extension</li>
           <li><code>{`{filename}`}</code> - Full filename</li>
@@ -654,7 +656,7 @@ name_matches = "invoice*.pdf"
 
 [rule.action]
 type = "rename"
-pattern = "{date:YYYY-MM-DD}_{name}.{ext}"`}</code></pre>
+pattern = "{date:%Y-%m-%d}_{name}.{ext}"`}</code></pre>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- Expand template variables in move and copy destination directories
- Preserve the original filename after destination expansion
- Add coverage for date, file-variable, and overwrite behavior
- Update README, configuration docs, and website documentation
- Correct date format examples to use `strftime` syntax
